### PR TITLE
Prefetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.classpath
 /.project
 /.settings/
+/.idea/
 affine-fusion

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -6,12 +6,45 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import mpicbg.spim.data.SpimData;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.registration.ViewRegistration;
 import mpicbg.spim.data.registration.ViewRegistrations;
+import mpicbg.spim.data.registration.ViewTransformAffine;
+import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.FinalDimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.preibisch.bigstitcher.spark.abstractcmdline.AbstractSelectableViews;
+import net.preibisch.bigstitcher.spark.util.BDVSparkInstantiateViewSetup;
+import net.preibisch.bigstitcher.spark.util.Downsampling;
+import net.preibisch.bigstitcher.spark.util.Grid;
+import net.preibisch.bigstitcher.spark.util.Import;
+import net.preibisch.bigstitcher.spark.util.N5Util;
+import net.preibisch.bigstitcher.spark.util.Spark;
+import net.preibisch.bigstitcher.spark.util.ViewUtil;
 import net.preibisch.bigstitcher.spark.util.ViewUtil.PrefetchPixel;
+import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
+import net.preibisch.mvrecon.process.export.ExportN5API.StorageType;
+import net.preibisch.mvrecon.process.export.ExportTools;
+import net.preibisch.mvrecon.process.export.ExportTools.InstantiateViewSetup;
+import net.preibisch.mvrecon.process.fusion.FusionTools;
+import net.preibisch.mvrecon.process.interestpointregistration.TransformationTools;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -22,39 +55,6 @@ import org.janelia.saalfeldlab.n5.GzipCompression;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-
-import mpicbg.spim.data.SpimDataException;
-import mpicbg.spim.data.registration.ViewRegistration;
-import mpicbg.spim.data.registration.ViewTransformAffine;
-import mpicbg.spim.data.sequence.ViewId;
-import net.imglib2.FinalDimensions;
-import net.imglib2.FinalInterval;
-import net.imglib2.Interval;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.converter.Converters;
-import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.type.numeric.integer.ShortType;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.type.numeric.integer.UnsignedShortType;
-import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Intervals;
-import net.imglib2.util.Util;
-import net.imglib2.view.Views;
-import net.preibisch.bigstitcher.spark.abstractcmdline.AbstractSelectableViews;
-import net.preibisch.bigstitcher.spark.util.BDVSparkInstantiateViewSetup;
-import net.preibisch.bigstitcher.spark.util.Downsampling;
-import net.preibisch.bigstitcher.spark.util.Grid;
-import net.preibisch.bigstitcher.spark.util.Import;
-import net.preibisch.bigstitcher.spark.util.N5Util;
-import net.preibisch.bigstitcher.spark.util.Spark;
-import net.preibisch.bigstitcher.spark.util.ViewUtil;
-import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
-import net.preibisch.mvrecon.process.export.ExportN5API.StorageType;
-import net.preibisch.mvrecon.process.export.ExportTools;
-import net.preibisch.mvrecon.process.export.ExportTools.InstantiateViewSetup;
-import net.preibisch.mvrecon.process.fusion.FusionTools;
-import net.preibisch.mvrecon.process.interestpointregistration.TransformationTools;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
@@ -114,6 +114,14 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 	// TODO: support create custom downsampling pyramids, null is fine for now (used by multiRes later)
 	private int[][] downsamplings;
+
+
+	/**
+	 * Assumes that
+	 * at most 8 views are required per output block, and
+	 * at most 8 input blocks per output block are required from one input view per output block.
+	 */
+	static final int N_PREFETCH_THREADS = 72;
 
 	@Override
 	public Void call() throws Exception
@@ -231,15 +239,10 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 		//ImageJFunctions.show( virtual, Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() ) );
 		//SimpleMultiThreading.threadHaltUnClean();
 
-		final String n5Path = this.n5Path;
 		final String n5Dataset = this.n5Dataset != null ? this.n5Dataset : Import.createBDVPath( this.bdvString, this.storageType );
-		final String xmlPath = this.xmlPath;
-		final StorageType storageType = this.storageType;
 		final Compression compression = new GzipCompression( 1 );
 
-		final boolean uint8 = this.uint8;
-		final boolean uint16 = this.uint16;
-		final double minIntensity = (uint8 || uint16 ) ? this.minIntensity : 0;
+		final double minIntensity = ( uint8 || uint16 ) ? this.minIntensity : 0;
 		final double range;
 		if ( uint8 )
 			range = ( this.maxIntensity - this.minIntensity ) / 255.0;
@@ -250,8 +253,6 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 		// TODO: improve (e.g. make ViewId serializable)
 		final int[][] serializedViewIds = Spark.serializeViewIds(viewIdsGlobal);
-		final boolean useAF = preserveAnisotropy;
-		final double af = anisotropyFactor;
 
 		try
 		{
@@ -303,8 +304,8 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 						blockSize,
 						downsamplings,
 						viewId,
-						this.n5Path,
-						this.xmlOutPath,
+						n5Path,
+						xmlOutPath,
 						instantiate ) )
 				{
 					System.out.println( "Failed to write metadata for '" + n5Dataset + "'." );
@@ -335,7 +336,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 				xmlPath,
 				preserveAnisotropy,
 				anisotropyFactor,
-				boundingBox,
+				minBB,
 				n5Path,
 				n5Dataset,
 				bdvString,
@@ -344,7 +345,8 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 				uint8,
 				uint16,
 				minIntensity,
-				range ) );
+				range,
+				blockSize ) );
 
 		if ( this.downsamplings != null )
 		{
@@ -390,13 +392,8 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 
 
-
-
-
-
-	private static class WriteSuperBlock implements VoidFunction< long[][] >
+	static class WriteSuperBlock implements VoidFunction< long[][] >
 	{
-
 		private final String xmlPath;
 
 		private final boolean preserveAnisotropy;
@@ -404,8 +401,6 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 		private final double anisotropyFactor;
 
 		private final long[] minBB;
-
-		private final long[] maxBB;
 
 		private final String n5Path;
 
@@ -425,12 +420,13 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 		private final double range;
 
+		private final int[] blockSize;
 
 		public WriteSuperBlock(
 				final String xmlPath,
 				final boolean preserveAnisotropy,
 				final double anisotropyFactor,
-				final BoundingBox boundingBox,
+				final long[] minBB,
 				final String n5Path,
 				final String n5Dataset,
 				final String bdvString,
@@ -439,13 +435,13 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 				final boolean uint8,
 				final boolean uint16,
 				final double minIntensity,
-				final double range )
+				final double range,
+				final int[] blockSize )
 		{
 			this.xmlPath = xmlPath;
 			this.preserveAnisotropy = preserveAnisotropy;
 			this.anisotropyFactor = anisotropyFactor;
-			this.minBB = boundingBox.minAsLongArray();
-			this.maxBB = boundingBox.maxAsLongArray();
+			this.minBB = minBB;
 			this.n5Path = n5Path;
 			this.n5Dataset = n5Dataset;
 			this.bdvString = bdvString;
@@ -455,21 +451,89 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 			this.uint16 = uint16;
 			this.minIntensity = minIntensity;
 			this.range = range;
+			this.blockSize = blockSize;
+		}
+
+		/**
+		 * Find all views among the given {@code viewIds} that overlap the given {@code interval}.
+		 * The image interval of each view is transformed into world coordinates
+		 * and checked for overlap with {@code interval}, with a conservative
+		 * extension of 2 pixels in each direction.
+		 *
+		 * @param spimData contains bounds and registrations for all views
+		 * @param viewIds which views to check
+		 * @param interval interval in world coordinates
+		 * @return views that overlap {@code interval}
+		 */
+		private static List<ViewId> findOverlappingViews(
+				final SpimData spimData,
+				final List<ViewId> viewIds,
+				final Interval interval )
+		{
+			final List< ViewId > overlapping = new ArrayList<>();
+
+			// expand to be conservative ...
+			final Interval expandedInterval = Intervals.expand( interval, 2 );
+
+			for ( final ViewId viewId : viewIds )
+			{
+				final Interval bounds = ViewUtil.getTransformedBoundingBox( spimData, viewId );
+				if ( ViewUtil.overlaps( expandedInterval, bounds ) )
+					overlapping.add( viewId );
+			}
+
+			return overlapping;
+		}
+
+		private < T extends NativeType< T > > RandomAccessibleInterval< T > convertToOutputType( RandomAccessibleInterval< FloatType > rai )
+		{
+			if ( uint8 )
+			{
+				return ( RandomAccessibleInterval< T > ) Converters.convert(
+						rai, ( i, o ) -> o.setReal( ( i.get() - minIntensity ) / range ),
+						new UnsignedByteType() );
+			}
+			else if ( uint16 )
+			{
+				if ( bdvString != null && StorageType.HDF5.equals( storageType ) )
+				{
+					// TODO (TP): Revise the following .. This is probably fixed now???
+					// Tobias: unfortunately I store as short and treat it as unsigned short in Java.
+					// The reason is, that when I wrote this, the jhdf5 library did not support unsigned short. It's terrible and should be fixed.
+					// https://github.com/bigdataviewer/bigdataviewer-core/issues/154
+					// https://imagesc.zulipchat.com/#narrow/stream/327326-BigDataViewer/topic/XML.2FHDF5.20specification
+					return ( RandomAccessibleInterval< T > ) Converters.convert(
+							rai, ( i, o ) -> o.set( UnsignedShortType.getCodedSignedShort( ( int ) Util.round( ( i.get() - minIntensity ) / range ) ) ),
+							new ShortType() );
+				}
+				else
+				{
+					return ( RandomAccessibleInterval< T > ) Converters.convert(
+							rai, ( i, o ) -> o.setReal( ( i.get() - minIntensity ) / range ),
+							new UnsignedShortType() );
+				}
+			}
+			else
+			{
+				return ( RandomAccessibleInterval< T > ) rai;
+			}
 		}
 
 		@Override
 		public void call( final long[][] gridBlock ) throws Exception
 		{
+			final int n = blockSize.length;
+
 			// The min coordinates of the block that this job renders (in pixels)
-			final long[] currentBlockOffset = gridBlock[ 0 ];
+			final long[] superBlockOffset = new long[ n ];
+			Arrays.setAll( superBlockOffset, d -> gridBlock[ 0 ][ d ] + minBB[ d ] );
 
 			// The size of the block that this job renders (in pixels)
-			final long[] currentBlockSize = gridBlock[ 1 ];
+			final long[] superBlockSize = gridBlock[ 1 ];
 
 			// The min grid coordinate of the block that this job renders, in units of the output grid.
 			// Note, that the block that is rendered may cover multiple output grid cells.
 			final long[] outputGridOffset = gridBlock[ 2 ];
-
 
 
 
@@ -483,9 +547,9 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 			final SpimData2 dataLocal = Spark.getSparkJobSpimData2("", xmlPath);
 			final List< ViewId > viewIds = Spark.deserializeViewIds( serializedViewIds );
 
-			// If requested, preserve the anisotropy of the data (output
-			// data has same anisotropy as input data) by prepending an
-			// affine to each ViewRegistration
+			// If requested, preserve the anisotropy of the data (such that
+			// output data has the same anisotropy as input data) by prepending
+			// an affine to each ViewRegistration
 			if ( preserveAnisotropy )
 			{
 				final AffineTransform3D aniso = new AffineTransform3D();
@@ -505,111 +569,170 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 			}
 
 
+			final long[] gridPos = new long[ n ];
+			final long[] fusedBlockMin = new long[ n ];
+			final long[] fusedBlockMax = new long[ n ];
+			final Interval fusedBlock = FinalInterval.wrap( fusedBlockMin, fusedBlockMax );
 
-
-
-
-
-
-
-
-
-
-			// be smarter, test which ViewIds are actually needed for the block we want to fuse
-			final Interval fusedBlock =
-					Intervals.translate(
-							FinalInterval.createMinSize( currentBlockOffset, currentBlockSize ),
-							minBB ); // min of the randomaccessbileinterval
-
-			// recover views to process
-			final ArrayList< ViewId > viewIdsLocal = new ArrayList<>();
-			final List< Callable< Object > > prefetch = new ArrayList<>();
-			for ( final ViewId viewId : viewIds )
-			{
-				// expand to be conservative ...
-				final Interval boundingBoxLocal = ViewUtil.getTransformedBoundingBox( dataLocal, viewId );
-				final Interval bounds = Intervals.expand( boundingBoxLocal, 2 );
-
-				if ( ViewUtil.overlaps( fusedBlock, bounds ) )
-				{
-					// determine which Cells exactly we need to compute the fused block
-					final List< PrefetchPixel< ? > > blocks = ViewUtil.findOverlappingBlocks( dataLocal, viewId, fusedBlock );
-					if ( !blocks.isEmpty() )
-					{
-						prefetch.addAll( blocks );
-						viewIdsLocal.add( viewId );
-					}
-				}
-			}
-
-			//SimpleMultiThreading.threadWait( 10000 );
-
-			// nothing to save...
-			if ( viewIdsLocal.isEmpty() )
-				return;
-
-			// prefetch cells: each cell on a separate thread
-			final ExecutorService executor = Executors.newFixedThreadPool( prefetch.size() );
-			final List< Future< Object > > prefetched = executor.invokeAll( prefetch );
-			executor.shutdown();
-
-			final RandomAccessibleInterval< FloatType > source = FusionTools.fuseVirtual(
-					dataLocal,
-					viewIdsLocal,
-					FinalInterval.wrap( minBB, maxBB )
-			);
+			// pre-filter views that overlap the superBlock
+			Arrays.setAll( fusedBlockMin, d -> superBlockOffset[ d ] );
+			Arrays.setAll( fusedBlockMax, d -> superBlockOffset[ d ] + superBlockSize[ d ] - 1 );
+			final List< ViewId > overlappingViews = findOverlappingViews( dataLocal, viewIds, fusedBlock );
 
 			final N5Writer executorVolumeWriter = N5Util.createWriter( n5Path, storageType );
+			final ExecutorService prefetchExecutor = Executors.newFixedThreadPool( N_PREFETCH_THREADS );
 
-			if ( uint8 )
+			final CellGrid blockGrid = new CellGrid( superBlockSize, blockSize );
+			final int numCells = ( int ) Intervals.numElements( blockGrid.getGridDimensions() );
+			for ( int gridIndex = 0; gridIndex < numCells; ++gridIndex )
 			{
-				final RandomAccessibleInterval< UnsignedByteType > sourceUINT8 =
-						Converters.convert(
-								source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
-								new UnsignedByteType());
+				blockGrid.getCellGridPositionFlat( gridIndex, gridPos );
+				blockGrid.getCellInterval( gridPos, fusedBlockMin, fusedBlockMax );
 
-				final RandomAccessibleInterval< UnsignedByteType > sourceGridBlock = Views.offsetInterval( sourceUINT8, currentBlockOffset, currentBlockSize );
-				//N5Utils.saveNonEmptyBlock(sourceGridBlock, n5Writer, n5Dataset, gridBlock[2], new UnsignedByteType());
-				N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-			}
-			else if ( uint16 )
-			{
-				final RandomAccessibleInterval< UnsignedShortType > sourceUINT16 =
-						Converters.convert(
-								source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
-								new UnsignedShortType());
-
-				if ( bdvString != null && StorageType.HDF5.equals( storageType ) )
+				for ( int d = 0; d < n; ++d )
 				{
-					// TODO (TP): Revise the following .. This is probably fixed now???
-					// Tobias: unfortunately I store as short and treat it as unsigned short in Java.
-					// The reason is, that when I wrote this, the jhdf5 library did not support unsigned short. It's terrible and should be fixed.
-					// https://github.com/bigdataviewer/bigdataviewer-core/issues/154
-					// https://imagesc.zulipchat.com/#narrow/stream/327326-BigDataViewer/topic/XML.2FHDF5.20specification
-					final RandomAccessibleInterval< ShortType > sourceINT16 =
-							Converters.convertRAI( sourceUINT16, (i,o)->o.set( i.getShort() ), new ShortType() );
-
-					final RandomAccessibleInterval< ShortType > sourceGridBlock = Views.offsetInterval( sourceINT16, currentBlockOffset, currentBlockSize );
-					N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+					gridPos[ d ] += outputGridOffset[ d ];
+					fusedBlockMin[ d ] += superBlockOffset[ d ];
+					fusedBlockMax[ d ] += superBlockOffset[ d ];
 				}
-				else
+				// gridPos is now the grid coordinate in the N5 output
+
+				// determine which Cells and Views we need to compute the fused block
+				final OverlappingBlocks overlappingBlocks = OverlappingBlocks.find( dataLocal, overlappingViews, fusedBlock );
+
+				if ( overlappingBlocks.overlappingViews().isEmpty() )
+					continue;
+
+				try ( AutoCloseable prefetched = overlappingBlocks.prefetch( prefetchExecutor ) )
 				{
-					final RandomAccessibleInterval< UnsignedShortType > sourceGridBlock = Views.offsetInterval( sourceUINT16, currentBlockOffset, currentBlockSize );
-					N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+					// TODO (TP) Can we go lower-level here? This does redundant view filtering internally:
+					final RandomAccessibleInterval< FloatType > source = FusionTools.fuseVirtual(
+							dataLocal,
+							overlappingBlocks.overlappingViews(),
+							fusedBlock );
+
+					// TODO (TP) make generics work here:
+					final RandomAccessibleInterval convertedSource = convertToOutputType( source );
+					N5Utils.saveBlock( convertedSource, executorVolumeWriter, n5Dataset, gridPos );
 				}
 			}
-			else
-			{
-				final RandomAccessibleInterval< FloatType > sourceGridBlock = Views.offsetInterval( source, currentBlockOffset, currentBlockSize );
-				N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-			}
-
-			// let go of references to the prefetched cells
-			prefetched.clear();
+			prefetchExecutor.shutdown();
 
 			// not HDF5
 			if ( N5Util.hdf5DriverVolumeWriter != executorVolumeWriter )
 				executorVolumeWriter.close();
+
+		}
+	}
+
+
+
+	/**
+	 * Determine which input blocks overlap a given interval using {@link
+	 * OverlappingBlocks#find}. Then prefetch those blocks using {@link
+	 * OverlappingBlocks#prefetch}.
+	 */
+	static class OverlappingBlocks
+	{
+		/**
+		 * Determine which of the given {@code viewIds} have blocks that overlap
+		 * {@code interval}.
+		 *
+		 * @param data
+		 * 		has all images and transformations
+		 * @param viewIds
+		 * 		which views to check
+		 * @param interval
+		 * 		the interval that will be processed (in world coordinates)
+		 * @return list of views with overlapping blocks, and a prefetcher for those blocks.
+		 */
+		public static OverlappingBlocks find(
+				final SpimData data,
+				final List<ViewId> viewIds,
+				Interval interval )
+		{
+			final List< ViewId > overlapping = new ArrayList<>();
+			final List< Callable< Object > > prefetch = new ArrayList<>();
+
+			// expand to be conservative ...
+			final Interval expandedInterval = Intervals.expand( interval, 2 );
+
+			for ( final ViewId viewId : viewIds )
+			{
+				final Interval bounds = ViewUtil.getTransformedBoundingBox( data, viewId );
+				if ( ViewUtil.overlaps( expandedInterval, bounds ) )
+				{
+					// determine which Cells exactly we need to compute the fused block
+					final List< PrefetchPixel< ? > > blocks = ViewUtil.findOverlappingBlocks( data, viewId, interval );
+					if ( !blocks.isEmpty() )
+					{
+						prefetch.addAll( blocks );
+						overlapping.add( viewId );
+					}
+				}
+			}
+
+			return new OverlappingBlocks( overlapping, prefetch );
+		}
+
+		/**
+		 * Get the list of views with overlapping blocks.
+		 *
+		 * @return list of views with overlapping blocks
+		 */
+		public List< ViewId > overlappingViews()
+		{
+			return overlappingViews;
+		}
+
+		/**
+		 * Prefetch all overlapping blocks.
+		 * <p>
+		 * The returned {@code AutoCloseable} holds strong reference to all
+		 * prefetched blocks (until it is closed), preventing those blocks
+		 * from being garbage-collected.
+		 *
+		 * @param executor blocks are loaded in parallel using this executor
+		 *
+		 * @return {@code AutoCloseable} that holds strong reference to all prefetched blocks (until it is closed), preventing those blocks from being garbage-collected.
+		 */
+		public AutoCloseable prefetch( final ExecutorService executor ) throws InterruptedException
+		{
+			return new Prefetched( executor.invokeAll( prefetchBlocks ) );
+		}
+
+		private final List< ViewId > overlappingViews;
+
+		private final List< Callable< Object > > prefetchBlocks;
+
+		private OverlappingBlocks(
+				final List< ViewId > overlappingViews,
+				final List< Callable< Object > > prefetchBlocks )
+		{
+			this.overlappingViews = overlappingViews;
+			this.prefetchBlocks = prefetchBlocks;
+		}
+
+		/**
+		 * Result of {@link OverlappingBlocks#prefetch}. Holds strong
+		 * references to prefetched data, until it is {@link #close()
+		 * closed}.
+		 */
+		private static class Prefetched implements AutoCloseable
+		{
+			private final List< Future< Object > > prefetched;
+
+			public Prefetched( final List< Future< Object > > prefetched )
+			{
+				this.prefetched = prefetched;
+			}
+
+			@Override
+			public void close() throws Exception
+			{
+				// let go of references to the prefetched cells
+				prefetched.clear();
+			}
 		}
 	}
 }

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -15,6 +15,7 @@ import net.preibisch.bigstitcher.spark.util.ViewUtil.PrefetchPixel;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.VoidFunction;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -330,138 +331,20 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 		final JavaRDD<long[][]> rdd = sc.parallelize( grid );
 
 		final long time = System.currentTimeMillis();
-		rdd.foreach(
-				gridBlock -> {
-
-					// The min coordinates of the block that this job renders (in pixels)
-					final long[] currentBlockOffset = gridBlock[ 0 ];
-
-					// The size of the block that this job renders (in pixels)
-					final long[] currentBlockSize = gridBlock[ 1 ];
-
-					// The min grid coordinate of the block that this job renders, in units of the output grid.
-					// Note, that the block that is rendered may cover multiple output grid cells.
-					final long[] outputGridOffset = gridBlock[ 2 ];
-
-					// custom serialization
-					final SpimData2 dataLocal = Spark.getSparkJobSpimData2("", xmlPath);
-					final List< ViewId > viewIds2 = Spark.deserializeViewIds( serializedViewIds );
-
-					// be smarter, test which ViewIds are actually needed for the block we want to fuse
-					final Interval fusedBlock =
-							Intervals.translate(
-									FinalInterval.createMinSize( currentBlockOffset, currentBlockSize ),
-									minBB ); // min of the randomaccessbileinterval
-
-					// recover views to process
-					final ArrayList< ViewId > viewIdsLocal = new ArrayList<>();
-					final List< Callable< Object > > prefetch = new ArrayList<>();
-
-					if ( useAF )
-					{
-						final AffineTransform3D aniso = new AffineTransform3D();
-						aniso.set(
-								1.0, 0.0, 0.0, 0.0,
-								0.0, 1.0, 0.0, 0.0,
-								0.0, 0.0, 1.0 / af, 0.0 );
-						final ViewTransformAffine preserveAnisotropy = new ViewTransformAffine( "preserve anisotropy", aniso );
-
-						final ViewRegistrations registrations = dataLocal.getViewRegistrations();
-						for ( final ViewId viewId : viewIds2 )
-						{
-							// get updated registration for views to fuse AND all other views that may influence the fusion
-							final ViewRegistration vr = registrations.getViewRegistration( viewId );
-							vr.preconcatenateTransform( preserveAnisotropy );
-							vr.updateModel();
-						}
-					}
-
-					for ( final ViewId viewId : viewIds2 )
-					{
-						// expand to be conservative ...
-						final Interval boundingBoxLocal = ViewUtil.getTransformedBoundingBox( dataLocal, viewId );
-						final Interval bounds = Intervals.expand( boundingBoxLocal, 2 );
-
-						if ( ViewUtil.overlaps( fusedBlock, bounds ) )
-						{
-							// determine which Cells exactly we need to compute the fused block
-							final List< PrefetchPixel< ? > > blocks = ViewUtil.findOverlappingBlocks( dataLocal, viewId, fusedBlock );
-							if ( !blocks.isEmpty() )
-							{
-								prefetch.addAll( blocks );
-								viewIdsLocal.add( viewId );
-							}
-						}
-					}
-
-					//SimpleMultiThreading.threadWait( 10000 );
-
-					// nothing to save...
-					if ( viewIdsLocal.size() == 0 )
-						return;
-
-					// prefetch cells: each cell on a separate thread
-					final ExecutorService executor = Executors.newFixedThreadPool( prefetch.size() );
-					final List< Future< Object > > prefetched = executor.invokeAll( prefetch );
-					executor.shutdown();
-
-					final RandomAccessibleInterval<FloatType> source = FusionTools.fuseVirtual(
-								dataLocal,
-								viewIdsLocal,
-								new FinalInterval(minBB, maxBB)
-					);
-
-					final N5Writer executorVolumeWriter = N5Util.createWriter( n5Path, storageType );
-
-					if ( uint8 )
-					{
-						final RandomAccessibleInterval< UnsignedByteType > sourceUINT8 =
-								Converters.convert(
-										source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
-										new UnsignedByteType());
-
-						final RandomAccessibleInterval< UnsignedByteType > sourceGridBlock = Views.offsetInterval( sourceUINT8, currentBlockOffset, currentBlockSize );
-						//N5Utils.saveNonEmptyBlock(sourceGridBlock, n5Writer, n5Dataset, gridBlock[2], new UnsignedByteType());
-						N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-					}
-					else if ( uint16 )
-					{
-						final RandomAccessibleInterval< UnsignedShortType > sourceUINT16 =
-								Converters.convert(
-										source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
-										new UnsignedShortType());
-
-						if ( bdvString != null && StorageType.HDF5.equals( storageType ) )
-						{
-							// Tobias: unfortunately I store as short and treat it as unsigned short in Java.
-							// The reason is, that when I wrote this, the jhdf5 library did not support unsigned short. It's terrible and should be fixed.
-							// https://github.com/bigdataviewer/bigdataviewer-core/issues/154
-							// https://imagesc.zulipchat.com/#narrow/stream/327326-BigDataViewer/topic/XML.2FHDF5.20specification
-							final RandomAccessibleInterval< ShortType > sourceINT16 =
-									Converters.convertRAI( sourceUINT16, (i,o)->o.set( i.getShort() ), new ShortType() );
-
-							final RandomAccessibleInterval< ShortType > sourceGridBlock = Views.offsetInterval( sourceINT16, currentBlockOffset, currentBlockSize );
-							N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-						}
-						else
-						{
-							final RandomAccessibleInterval< UnsignedShortType > sourceGridBlock = Views.offsetInterval( sourceUINT16, currentBlockOffset, currentBlockSize );
-							N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-						}
-					}
-					else
-					{
-						final RandomAccessibleInterval< FloatType > sourceGridBlock = Views.offsetInterval( source, currentBlockOffset, currentBlockSize );
-						N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
-					}
-
-					// let go of references to the prefetched cells
-					prefetched.clear();
-
-					// not HDF5
-					if ( N5Util.hdf5DriverVolumeWriter != executorVolumeWriter )
-						executorVolumeWriter.close();
-				});
+		rdd.foreach( new WriteSuperBlock(
+				xmlPath,
+				preserveAnisotropy,
+				anisotropyFactor,
+				boundingBox,
+				n5Path,
+				n5Dataset,
+				bdvString,
+				storageType,
+				serializedViewIds,
+				uint8,
+				uint16,
+				minIntensity,
+				range ) );
 
 		if ( this.downsamplings != null )
 		{
@@ -505,4 +388,228 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 		System.exit(new CommandLine(new SparkAffineFusion()).execute(args));
 	}
 
+
+
+
+
+
+
+	private static class WriteSuperBlock implements VoidFunction< long[][] >
+	{
+
+		private final String xmlPath;
+
+		private final boolean preserveAnisotropy;
+
+		private final double anisotropyFactor;
+
+		private final long[] minBB;
+
+		private final long[] maxBB;
+
+		private final String n5Path;
+
+		private final String n5Dataset;
+
+		private final String bdvString;
+
+		private final StorageType storageType;
+
+		private final int[][] serializedViewIds;
+
+		private final boolean uint8;
+
+		private final boolean uint16;
+
+		private final double minIntensity;
+
+		private final double range;
+
+
+		public WriteSuperBlock(
+				final String xmlPath,
+				final boolean preserveAnisotropy,
+				final double anisotropyFactor,
+				final BoundingBox boundingBox,
+				final String n5Path,
+				final String n5Dataset,
+				final String bdvString,
+				final StorageType storageType,
+				final int[][] serializedViewIds,
+				final boolean uint8,
+				final boolean uint16,
+				final double minIntensity,
+				final double range )
+		{
+			this.xmlPath = xmlPath;
+			this.preserveAnisotropy = preserveAnisotropy;
+			this.anisotropyFactor = anisotropyFactor;
+			this.minBB = boundingBox.minAsLongArray();
+			this.maxBB = boundingBox.maxAsLongArray();
+			this.n5Path = n5Path;
+			this.n5Dataset = n5Dataset;
+			this.bdvString = bdvString;
+			this.storageType = storageType;
+			this.serializedViewIds = serializedViewIds;
+			this.uint8 = uint8;
+			this.uint16 = uint16;
+			this.minIntensity = minIntensity;
+			this.range = range;
+		}
+
+		@Override
+		public void call( final long[][] gridBlock ) throws Exception
+		{
+			// The min coordinates of the block that this job renders (in pixels)
+			final long[] currentBlockOffset = gridBlock[ 0 ];
+
+			// The size of the block that this job renders (in pixels)
+			final long[] currentBlockSize = gridBlock[ 1 ];
+
+			// The min grid coordinate of the block that this job renders, in units of the output grid.
+			// Note, that the block that is rendered may cover multiple output grid cells.
+			final long[] outputGridOffset = gridBlock[ 2 ];
+
+
+
+
+
+			// --------------------------------------------------------
+			// initialization work that is happening in every job,
+			// independent of gridBlock parameters
+			// --------------------------------------------------------
+
+			// custom serialization
+			final SpimData2 dataLocal = Spark.getSparkJobSpimData2("", xmlPath);
+			final List< ViewId > viewIds = Spark.deserializeViewIds( serializedViewIds );
+
+			// If requested, preserve the anisotropy of the data (output
+			// data has same anisotropy as input data) by prepending an
+			// affine to each ViewRegistration
+			if ( preserveAnisotropy )
+			{
+				final AffineTransform3D aniso = new AffineTransform3D();
+				aniso.set(
+						1.0, 0.0, 0.0, 0.0,
+						0.0, 1.0, 0.0, 0.0,
+						0.0, 0.0, 1.0 / anisotropyFactor, 0.0 );
+				final ViewTransformAffine preserveAnisotropy = new ViewTransformAffine( "preserve anisotropy", aniso );
+
+				final ViewRegistrations registrations = dataLocal.getViewRegistrations();
+				for ( final ViewId viewId : viewIds )
+				{
+					final ViewRegistration vr = registrations.getViewRegistration( viewId );
+					vr.preconcatenateTransform( preserveAnisotropy );
+					vr.updateModel();
+				}
+			}
+
+
+
+
+
+
+
+
+
+
+
+
+			// be smarter, test which ViewIds are actually needed for the block we want to fuse
+			final Interval fusedBlock =
+					Intervals.translate(
+							FinalInterval.createMinSize( currentBlockOffset, currentBlockSize ),
+							minBB ); // min of the randomaccessbileinterval
+
+			// recover views to process
+			final ArrayList< ViewId > viewIdsLocal = new ArrayList<>();
+			final List< Callable< Object > > prefetch = new ArrayList<>();
+			for ( final ViewId viewId : viewIds )
+			{
+				// expand to be conservative ...
+				final Interval boundingBoxLocal = ViewUtil.getTransformedBoundingBox( dataLocal, viewId );
+				final Interval bounds = Intervals.expand( boundingBoxLocal, 2 );
+
+				if ( ViewUtil.overlaps( fusedBlock, bounds ) )
+				{
+					// determine which Cells exactly we need to compute the fused block
+					final List< PrefetchPixel< ? > > blocks = ViewUtil.findOverlappingBlocks( dataLocal, viewId, fusedBlock );
+					if ( !blocks.isEmpty() )
+					{
+						prefetch.addAll( blocks );
+						viewIdsLocal.add( viewId );
+					}
+				}
+			}
+
+			//SimpleMultiThreading.threadWait( 10000 );
+
+			// nothing to save...
+			if ( viewIdsLocal.isEmpty() )
+				return;
+
+			// prefetch cells: each cell on a separate thread
+			final ExecutorService executor = Executors.newFixedThreadPool( prefetch.size() );
+			final List< Future< Object > > prefetched = executor.invokeAll( prefetch );
+			executor.shutdown();
+
+			final RandomAccessibleInterval< FloatType > source = FusionTools.fuseVirtual(
+					dataLocal,
+					viewIdsLocal,
+					FinalInterval.wrap( minBB, maxBB )
+			);
+
+			final N5Writer executorVolumeWriter = N5Util.createWriter( n5Path, storageType );
+
+			if ( uint8 )
+			{
+				final RandomAccessibleInterval< UnsignedByteType > sourceUINT8 =
+						Converters.convert(
+								source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
+								new UnsignedByteType());
+
+				final RandomAccessibleInterval< UnsignedByteType > sourceGridBlock = Views.offsetInterval( sourceUINT8, currentBlockOffset, currentBlockSize );
+				//N5Utils.saveNonEmptyBlock(sourceGridBlock, n5Writer, n5Dataset, gridBlock[2], new UnsignedByteType());
+				N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+			}
+			else if ( uint16 )
+			{
+				final RandomAccessibleInterval< UnsignedShortType > sourceUINT16 =
+						Converters.convert(
+								source,(i, o) -> o.setReal( ( i.get() - minIntensity ) / range ),
+								new UnsignedShortType());
+
+				if ( bdvString != null && StorageType.HDF5.equals( storageType ) )
+				{
+					// TODO (TP): Revise the following .. This is probably fixed now???
+					// Tobias: unfortunately I store as short and treat it as unsigned short in Java.
+					// The reason is, that when I wrote this, the jhdf5 library did not support unsigned short. It's terrible and should be fixed.
+					// https://github.com/bigdataviewer/bigdataviewer-core/issues/154
+					// https://imagesc.zulipchat.com/#narrow/stream/327326-BigDataViewer/topic/XML.2FHDF5.20specification
+					final RandomAccessibleInterval< ShortType > sourceINT16 =
+							Converters.convertRAI( sourceUINT16, (i,o)->o.set( i.getShort() ), new ShortType() );
+
+					final RandomAccessibleInterval< ShortType > sourceGridBlock = Views.offsetInterval( sourceINT16, currentBlockOffset, currentBlockSize );
+					N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+				}
+				else
+				{
+					final RandomAccessibleInterval< UnsignedShortType > sourceGridBlock = Views.offsetInterval( sourceUINT16, currentBlockOffset, currentBlockSize );
+					N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+				}
+			}
+			else
+			{
+				final RandomAccessibleInterval< FloatType > sourceGridBlock = Views.offsetInterval( source, currentBlockOffset, currentBlockSize );
+				N5Utils.saveBlock( sourceGridBlock, executorVolumeWriter, n5Dataset, outputGridOffset );
+			}
+
+			// let go of references to the prefetched cells
+			prefetched.clear();
+
+			// not HDF5
+			if ( N5Util.hdf5DriverVolumeWriter != executorVolumeWriter )
+				executorVolumeWriter.close();
+		}
+	}
 }

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -335,6 +335,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 					// custom serialization
 					final SpimData2 dataLocal = Spark.getSparkJobSpimData2("", xmlPath);
+					final List< ViewId > viewIds2 = Spark.deserializeViewIds( serializedViewIds );
 
 					// be smarter, test which ViewIds are actually needed for the block we want to fuse
 					final Interval fusedBlock =
@@ -345,9 +346,8 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 					// recover views to process
 					final ArrayList< ViewId > viewIdsLocal = new ArrayList<>();
 
-					for ( int i = 0; i < serializedViewIds.length; ++i )
+					for ( final ViewId viewId : viewIds2 )
 					{
-						final ViewId viewId = Spark.deserializeViewIds(serializedViewIds, i);
 
 						if ( useAF )
 						{

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -265,13 +265,9 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 				dataType,
 				compression );
 
-		final List<long[][]> grid = Grid.create( dimensions, blockSize );
-
-		/*
-		// TODO: start doing this
+//		final List<long[][]> grid = Grid.create( dimensions, blockSize );
 
 		// using bigger blocksizes than being stored for efficiency (needed for very large datasets)
-
 		final List<long[][]> grid = Grid.create(dimensions,
 				new int[] {
 						blockSize[0] * 4,
@@ -279,7 +275,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 						blockSize[2] * 4
 				},
 				blockSize);
-		*/
+
 
 		System.out.println( "numBlocks = " + grid.size() );
 

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -7,7 +7,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import mpicbg.spim.data.registration.ViewRegistrations;
+import net.preibisch.bigstitcher.spark.util.ViewUtil.PrefetchPixel;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -346,6 +350,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 					// recover views to process
 					final ArrayList< ViewId > viewIdsLocal = new ArrayList<>();
+					final List< Callable< Object > > prefetch = new ArrayList<>();
 
 					if ( useAF )
 					{
@@ -374,11 +379,13 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 
 						if ( ViewUtil.overlaps( fusedBlock, bounds ) )
 						{
-							viewIdsLocal.add( viewId );
-
-							// TODO: which blocks exactly do we need and pre-fetch them using a simple getPixel call (or something like that) in the center of each block
-							// as long as the cache isn't cleared
-							// Tobi: keep the RA's to make sure that the cache can't be cleared - we want the outofmemory if that's the case
+							// determine which Cells exactly we need to compute the fused block
+							final List< PrefetchPixel< ? > > blocks = ViewUtil.findOverlappingBlocks( dataLocal, viewId, fusedBlock );
+							if ( !blocks.isEmpty() )
+							{
+								prefetch.addAll( blocks );
+								viewIdsLocal.add( viewId );
+							}
 						}
 					}
 
@@ -387,6 +394,12 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 					// nothing to save...
 					if ( viewIdsLocal.size() == 0 )
 						return;
+
+					// prefetch cells: each cell on a separate thread
+					final ExecutorService executor = Executors.newFixedThreadPool( prefetch.size() );
+					final List< Future< Object > > prefetched = executor.invokeAll( prefetch );
+					executor.shutdown();
+
 					final RandomAccessibleInterval<FloatType> source = FusionTools.fuseVirtual(
 								dataLocal,
 								viewIdsLocal,
@@ -436,6 +449,9 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 						final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(source, gridBlockOffset, gridBlockSize );
 						N5Utils.saveBlock(sourceGridBlock, executorVolumeWriter, n5Dataset, gridBlock[2]);
 					}
+
+					// let go of references to the prefetched cells
+					prefetched.clear();
 
 					// not HDF5
 					if ( N5Util.hdf5DriverVolumeWriter != executorVolumeWriter )

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
@@ -20,16 +20,14 @@ import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 
 public class Spark {
 
-	public static ArrayList< ViewId > deserializeViewIds( final int[][] serializedViewIds )
+	public static List< ViewId > deserializeViewIds( final int[][] serializedViewIds )
 	{
-		final ArrayList< ViewId > viewIds = new ArrayList<>();
-
-		for ( int i = 0; i < serializedViewIds.length; ++i )
-			viewIds.add( deserializeViewId( serializedViewIds[i] ) );
-
+		final List< ViewId > viewIds = new ArrayList<>( serializedViewIds.length );
+		for ( int[] sid : serializedViewIds )
+			viewIds.add( deserializeViewId( sid ) );
 		return viewIds;
 	}
-
+	
 	public static Pair<ViewId, ViewId> derserializeViewIdPairsForRDD( final int[][] serializedPair )
 	{
 		return new ValuePair<ViewId, ViewId>(deserializeViewId( serializedPair[ 0 ] ), deserializeViewId( serializedPair[ 1 ] ));

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -22,9 +22,13 @@ import net.imglib2.img.cell.CellGrid;
 import net.imglib2.iterator.IntervalIterator;
 import net.imglib2.iterator.LocalizingIntervalIterator;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.transform.integer.BoundingBox;
+import net.imglib2.transform.integer.MixedTransform;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.LinAlgHelpers;
 import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.MixedTransformView;
 
 public class ViewUtil
 {
@@ -114,7 +118,26 @@ public class ViewUtil
 		final AffineTransform3D imgToWorld = model.copy();
 		imgToWorld.concatenate( best.mipmapTransform );
 
-		if ( ! ( img instanceof AbstractCellImg ) )
+		RandomAccessible< ? > rai = best.img;
+
+		// strip one level of IntervalView, if present
+		if ( rai instanceof IntervalView )
+		{
+			rai = ( ( IntervalView< ? > ) rai ).getSource();
+		}
+
+		final MixedTransform transformToSource;
+		if ( rai instanceof MixedTransformView )
+		{
+			transformToSource = ( ( MixedTransformView< ? > ) rai ).getTransformToSource();
+			rai = ( ( MixedTransformView< ? > ) rai ).getSource();
+		}
+		else
+		{
+			transformToSource = null;
+		}
+
+		if ( ! ( rai instanceof AbstractCellImg ) )
 		{
 			throw new IllegalArgumentException( "TODO. Handling source types other than CellImg is not implemented yet" );
 		}
@@ -130,28 +153,55 @@ public class ViewUtil
 		//       re-used here to make the search more efficient. It should
 		//       provide more accurate results because it uses non-axis aligned
 		//       planes for intersection. See class FindRequiredBlocks.
+		//
+		// TODO: The following works for the hyperslice views currently produced by ZarrImageLoader
+		//       (from https://github.com/bigdataviewer/bigdataviewer-omezarr)
+		//       However, for the general case, the logic should be inverted:
+		//       Project the "fused" bounding box into source coordinates (see
+		//       above), because that is well-defined.
+		//       In contrast, the code below performs a projection onto the
+		//       "fused" hyper-slice, which can lead to non-required blocks
+		//       being loaded.
 
 		// iterate all cells (intervals) in grid
-		final CellGrid grid = ( ( AbstractCellImg< ?, ?, ?, ? > ) img ).getCellGrid();
-		final IntervalIterator gridIter = new LocalizingIntervalIterator( grid.getGridDimensions() );
+		final CellGrid grid = ( ( AbstractCellImg< ?, ?, ?, ? > ) rai ).getCellGrid();
+
 		final int n = grid.numDimensions();
 		final long[] gridPos = new long[ n ];
-		final long[] cellMin = new long[ n ];
-		final long[] cellMax = new long[ n ];
-		final Interval cellInterval = FinalInterval.wrap( cellMin, cellMax );
+		final BoundingBox cellBBox = new BoundingBox( n );
+		final long[] cellMin = cellBBox.corner1;
+		final long[] cellMax = cellBBox.corner2;
+
+		final BoundingBox projectedCellBBox;
+		final Interval projectedCellInterval;
+		final int m = img.numDimensions(); // should be always ==3
+		projectedCellBBox = new BoundingBox( m );
+		projectedCellInterval = FinalInterval.wrap( projectedCellBBox.corner1, projectedCellBBox.corner2 );
+
+		final IntervalIterator gridIter = new LocalizingIntervalIterator( grid.getGridDimensions() );
 		while( gridIter.hasNext() )
 		{
 			gridIter.fwd();
 			gridIter.localize( gridPos );
 			grid.getCellInterval( gridPos, cellMin, cellMax );
 
-			final Interval bounds =
-					Intervals.smallestContainingInterval(
-							imgToWorld.estimateBounds(
-									Intervals.expand( cellInterval, 1 ) ) );
+			if ( transformToSource == null )
+			{
+				expand( cellBBox, 1, projectedCellBBox );
+			}
+			else
+			{
+				transform( transformToSource, projectedCellBBox, cellBBox );
+				expand( projectedCellBBox, 1 );
+			}
+
+			final Interval bounds = Intervals.smallestContainingInterval(
+					imgToWorld.estimateBounds( projectedCellInterval ) );
 
 			if ( overlaps( bounds, fusedBlock ) )
-				prefetch.add( new PrefetchPixel( img, cellMin.clone() ) );
+			{
+				prefetch.add( new PrefetchPixel<>( rai, cellMin.clone() ) );
+			}
 		}
 
 //		prefetch.forEach( System.out::println );
@@ -293,6 +343,79 @@ public class ViewUtil
 				size[ d ] = ( float ) LinAlgHelpers.length( tmp );
 			}
 			return size;
+		}
+	}
+
+	/**
+	 * Grow {@code BoundingBox} by {@code border} pixels on every side.
+	 */
+	private static void expand( final BoundingBox bbox, final long border )
+	{
+		expand( bbox, border, bbox );
+	}
+
+	/**
+	 * Grow {@code BoundingBox} by {@code border} pixels on every side.
+	 */
+	private static void expand( final BoundingBox bbox, final long border, final BoundingBox expanded )
+	{
+		final int n = bbox.numDimensions();
+		for ( int d = 0; d < n; ++d )
+		{
+			expanded.corner1[ d ] = bbox.corner1[ d ] - border;
+			expanded.corner2[ d ] = bbox.corner2[ d ] + border;
+		}
+	}
+
+	/**
+	 * Reverse-apply {@code transform} to a target bounding box to obtain a
+	 * source bounding box.
+	 * <p>
+	 * Note that {@code transform} might not be invertible. For example. if
+	 * source is a hyper-slice of target, some dimensions of the target vector
+	 * are ignored.
+	 *
+	 * @param transform
+	 * 		the transform from target to source.
+	 * @param sourceBoundingBox
+	 * 		the source bounding box. <em>This is the output and is modified.</em>
+	 * @param targetBoundingBox
+	 * 		the target bounding box. <em>This is the input and is not modified.</em>
+	 */
+	private static void transform( final MixedTransform transform, final BoundingBox sourceBoundingBox, final BoundingBox targetBoundingBox )
+	{
+		assert sourceBoundingBox.numDimensions() == transform.numSourceDimensions();
+		assert targetBoundingBox.numDimensions() == transform.numTargetDimensions();
+		apply( transform, sourceBoundingBox.corner1, targetBoundingBox.corner1 );
+		apply( transform, sourceBoundingBox.corner2, targetBoundingBox.corner2 );
+		sourceBoundingBox.orderMinMax();
+	}
+
+	/**
+	 * Reverse-apply {@code transform} to a target vector to obtain a source vector.
+	 * <p>
+	 * Note that {@code transform} might not be invertible. For example. if
+	 * source is a hyper-slice of target, some dimensions of the target vector
+	 * are ignored.
+	 *
+	 * @param transform
+	 * 		transform from source to target.
+	 * @param source
+	 * 		set this to the source coordinates. <em>This is the output and is modified.</em>
+	 * @param target
+	 * 		target coordinates. <em>This is the input and is not modified.</em>
+	 */
+	private static void apply( MixedTransform transform, long[] source, long[] target )
+	{
+		assert source.length >= transform.numSourceDimensions();
+		assert target.length >= transform.numTargetDimensions();
+		for ( int d = 0; d < transform.numTargetDimensions(); ++d )
+		{
+			if ( !transform.getComponentZero( d ) )
+			{
+				long v = target[ d ] - transform.getTranslation( d );
+				source[ transform.getComponentMapping( d ) ] = transform.getComponentInversion( d ) ? -v : v;
+			}
 		}
 	}
 }

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -1,17 +1,33 @@
 package net.preibisch.bigstitcher.spark.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
 import mpicbg.spim.data.SpimData;
+import mpicbg.spim.data.generic.sequence.BasicMultiResolutionSetupImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicSetupImgLoader;
 import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
 import mpicbg.spim.data.sequence.ImgLoader;
 import mpicbg.spim.data.sequence.SetupImgLoader;
 import mpicbg.spim.data.sequence.ViewId;
-
 import net.imglib2.Dimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.iterator.IntervalIterator;
+import net.imglib2.iterator.LocalizingIntervalIterator;
+import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.Intervals;
+import net.imglib2.util.LinAlgHelpers;
+import net.imglib2.util.Util;
 
-public class ViewUtil {
+public class ViewUtil
+{
 
 	public static boolean overlaps( final Interval interval1, final Interval interval2 )
 	{
@@ -58,5 +74,225 @@ public class ViewUtil {
 	public static String viewIdToString(final ViewId viewId) {
 		return viewId == null ?
 			   null : "{\"setupId\": " + viewId.getViewSetupId() + ", \"timePointId\": " + viewId.getTimePointId() + "}";
+	}
+
+	/**
+	 * Find cells of the given {@code ViewId} required to produce the given
+	 * {@code fusedBlock} interval in world coordinates. If {@code data} is
+	 * multi-resolution, the best resolution is picked (the one that will be
+	 * used for fusion, too).
+	 *
+	 * @param data
+	 * 		has all images and transformations
+	 * @param viewId
+	 * 		which view to check
+	 * @param fusedBlock
+	 * 		the interval that will be processed (in world coordinates)
+	 *
+	 * @return a list of {@code PrefetchPixel} callables that will each prefetch one cell.
+	 */
+	public static List< PrefetchPixel< ? > > findOverlappingBlocks(
+			final SpimData data,
+			final ViewId viewId,
+			final Interval fusedBlock )
+	{
+		final List< PrefetchPixel< ? > > prefetch = new ArrayList<>();
+
+		final ImgLoader imgLoader = data.getSequenceDescription().getImgLoader();
+		final SetupImgLoader< ? > setupImgLoader = imgLoader.getSetupImgLoader( viewId.getViewSetupId() );
+		if ( setupImgLoader == null )
+		{
+			throw new IllegalArgumentException(
+					"failed to find setupImgLoader for " + viewIdToString( viewId ) + " in " + data );
+		}
+
+		final ViewRegistrations registrations = data.getViewRegistrations();
+		final AffineTransform3D model = registrations.getViewRegistration( viewId ).getModel();
+
+		final ImgAndMipmapTransform< ? > best = ImgAndMipmapTransform.forBestResolution( setupImgLoader, viewId.getTimePointId(), model );
+		final RandomAccessibleInterval< ? > img = best.img;
+		final AffineTransform3D imgToWorld = model.copy();
+		imgToWorld.concatenate( best.mipmapTransform );
+
+		if ( ! ( img instanceof AbstractCellImg ) )
+		{
+			throw new IllegalArgumentException( "TODO. Handling source types other than CellImg is not implemented yet" );
+		}
+
+		// Brute force search for overlapping cells:
+		//
+		// For each grid cell, estimate its bounding box in world space and test
+		// for intersection with fusedBlock
+		//
+		// TODO: BigVolumeViewer has a more sophisticated method for
+		//       intersecting the View Frustum with the source grid and
+		//       determining overlapping cells. This is similar and could be
+		//       re-used here to make the search more efficient. It should
+		//       provide more accurate results because it uses non-axis aligned
+		//       planes for intersection. See class FindRequiredBlocks.
+
+		// iterate all cells (intervals) in grid
+		final CellGrid grid = ( ( AbstractCellImg< ?, ?, ?, ? > ) img ).getCellGrid();
+		final IntervalIterator gridIter = new LocalizingIntervalIterator( grid.getGridDimensions() );
+		final int n = grid.numDimensions();
+		final long[] gridPos = new long[ n ];
+		final long[] cellMin = new long[ n ];
+		final long[] cellMax = new long[ n ];
+		final Interval cellInterval = FinalInterval.wrap( cellMin, cellMax );
+		while( gridIter.hasNext() )
+		{
+			gridIter.fwd();
+			gridIter.localize( gridPos );
+			grid.getCellInterval( gridPos, cellMin, cellMax );
+
+			final Interval bounds =
+					Intervals.smallestContainingInterval(
+							imgToWorld.estimateBounds(
+									Intervals.expand( cellInterval, 1 ) ) );
+
+			if ( overlaps( bounds, fusedBlock ) )
+				prefetch.add( new PrefetchPixel( img, cellMin.clone() ) );
+		}
+
+//		prefetch.forEach( System.out::println );
+		return prefetch;
+	}
+
+	/**
+	 * Callable that reads one pixel from a {@link RandomAccessible}, for
+	 * prefetching. In a cached `CellImg`, this will trigger the loading of the
+	 * containing `Cell`. Holding on to the pixel (of type 'T') returned by
+	 * 'call()' prevents garbage-collection of the cached 'Cell'!
+	 */
+	public static class PrefetchPixel< T > implements Callable< Object >
+	{
+		private final RandomAccessible< T > img;
+
+		private final long[] pos;
+
+		PrefetchPixel( final RandomAccessible< T > img, final long[] pos )
+		{
+			this.pos = pos;
+			this.img = img;
+		}
+
+		@Override
+		public T call()
+		{
+			return img.getAt( pos );
+		}
+
+		@Override
+		public String toString()
+		{
+			return "PrefetchPixel{" +
+					"img=" + img +
+					", pos=" + Arrays.toString( pos ) +
+					'}';
+		}
+	}
+
+	private static class ImgAndMipmapTransform< T >
+	{
+		final RandomAccessibleInterval< T > img;
+
+		final AffineTransform3D mipmapTransform;
+
+		private ImgAndMipmapTransform( final RandomAccessibleInterval< T > img, final AffineTransform3D mipmapTransform )
+		{
+			this.img = img;
+			this.mipmapTransform = mipmapTransform;
+		}
+
+		/**
+		 * Finds the  best resolution level using the same logic as {@code FusionTools.fuseVirtual()}
+		 *
+		 * TODO: Ideally, we would re-use the same code here. Refactor
+		 *       multiview-reconstruction to make that possible.
+		 */
+		static < T > ImgAndMipmapTransform< T > forBestResolution( BasicSetupImgLoader< T > setupImgLoader, int timepointId, final AffineTransform3D sourceToWorld )
+		{
+			if ( setupImgLoader instanceof BasicMultiResolutionSetupImgLoader )
+			{
+				final BasicMultiResolutionSetupImgLoader< T > mrSetupImgLoader = ( BasicMultiResolutionSetupImgLoader< T > ) setupImgLoader;
+				final double[][] mipmapResolutions = mrSetupImgLoader.getMipmapResolutions();
+				final AffineTransform3D[] mipmapTransforms = mrSetupImgLoader.getMipmapTransforms();
+
+				// Find the  best resolution level, using the same logic as
+				// FusionTools.fuseVirtual()
+				//
+
+				float acceptedError = 0.02f;
+
+				// assuming that this is the best one
+				int bestLevel = 0;
+				double bestScaling = 0;
+
+				float[] sizeMaxResolution = null;
+
+				// find the best level
+
+				for ( int level = 0; level < mipmapTransforms.length; ++level )
+				{
+					final double[] factors = mipmapResolutions[ level ];
+					AffineTransform3D levelToWorld = sourceToWorld.copy();
+					levelToWorld.concatenate( mipmapTransforms[ level ] );
+					final float[] size = getStepSize( levelToWorld );
+					if ( level == 0 )
+					{
+						sizeMaxResolution = size;
+						bestScaling = factors[ 0 ] * factors[ 1 ] * factors[ 2 ];
+					}
+					else
+					{
+						boolean isValid = true;
+						for ( int d = 0; d < 3; ++d )
+						{
+							if ( !( size[ d ] < 1.0 + acceptedError || Util.isApproxEqual( size[ d ], sizeMaxResolution[ d ], acceptedError ) ) )
+							{
+								isValid = false;
+								break;
+							}
+						}
+						if ( isValid )
+						{
+							final double totalScale = factors[ 0 ] * factors[ 1 ] * factors[ 2 ];
+							if ( totalScale > bestScaling )
+							{
+								bestScaling = totalScale;
+								bestLevel = level;
+							}
+						}
+					}
+				}
+
+				return new ImgAndMipmapTransform<>(
+						mrSetupImgLoader.getImage( timepointId, bestLevel ),
+						mipmapTransforms[ bestLevel ] );
+			}
+			else
+			{
+				// if setupImgLoader does not support not multi-resolution, use
+				// the full resolution image and an identity mipmap transform
+				return new ImgAndMipmapTransform<>(
+						setupImgLoader.getImage( timepointId ),
+						new AffineTransform3D() );
+			}
+		}
+
+		// TODO: return double[] instead of float[]. We use float[], because
+		//       multiview-reconstruction does, and we need to be compatible.
+		private static float[] getStepSize( final AffineTransform3D model )
+		{
+			final float[] size = new float[ 3 ];
+			final double[] tmp = new double[ 3 ];
+			for ( int d = 0; d < 3; ++d )
+			{
+				for ( int i = 0; i < 3; ++i )
+					tmp[ i ] = model.get( i, d );
+				size[ d ] = ( float ) LinAlgHelpers.length( tmp );
+			}
+			return size;
+		}
 	}
 }

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -58,7 +58,7 @@ public class ViewUtil {
 		final Dimensions dim = getDimensions( data, viewId );
 		final ViewRegistration reg = getViewRegistration( data, viewId );
 
-		return Intervals.largestContainedInterval( reg.getModel().estimateBounds( new FinalInterval( dim ) ) );
+		return Intervals.smallestContainingInterval( reg.getModel().estimateBounds( new FinalInterval( dim ) ) );
 	}
 
 	public static String viewIdToString(final ViewId viewId) {

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -43,7 +43,7 @@ public class ViewUtil {
 					"failed to find viewRegistration for " + viewIdToString(viewId) + " in " + data);
 		}
 
-		reg.updateModel();
+		reg.updateModel(); // TODO: This shouldn't be necessary, right?
 
 		return reg;
 	}

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -15,13 +15,7 @@ public class ViewUtil {
 
 	public static boolean overlaps( final Interval interval1, final Interval interval2 )
 	{
-		final Interval intersection = Intervals.intersect( interval1, interval2 );
-
-		for ( int d = 0; d < intersection.numDimensions(); ++d )
-			if ( intersection.dimension( d ) < 0 )
-				return false;
-
-		return true;
+		return !Intervals.isEmpty( Intervals.intersect( interval1, interval2 ) );
 	}
 
 	public static Dimensions getDimensions(final SpimData data, final ViewId viewId ) throws IllegalArgumentException

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/ViewUtil.java
@@ -48,6 +48,11 @@ public class ViewUtil {
 		return reg;
 	}
 
+	/**
+	 * Get the estimated bounding box of the specified view in world coordinates.
+	 * This transforms the image dimension for {@code viewId} with the {@code
+	 * ViewRegistration} for {@code viewId}, and takes the bounding box.
+	 */
 	public static Interval getTransformedBoundingBox( final SpimData data, final ViewId viewId ) throws IllegalArgumentException
 	{
 		final Dimensions dim = getDimensions( data, viewId );


### PR DESCRIPTION
* Determine which Cells exactly we need to compute the fused block, and prefetch every cell in a separate thread.

* Add "--blocksPerJob" argument.
  This specifies the "super-block multiplier", for example,
  with "2,2,2" each spark job will output 2x2x2 neighboring blocks.
  Prefetching and processing is done sequentially for each sub-block to avoid excessive memory usage for big super-blocks.

* Refactoring:
  Improve variable names. Add comments. Pull the Spark function lambda to separate class.

* Fix bounding box math: We want to use the containing Interval (bigger than RealInterval) instead of contained Interval (smaller) for the transformed bounding box.

