### PR TITLE
Update bigdataviewer-omezarr dependency version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.bigdataviewer</groupId>
             <artifactId>bigdataviewer-omezarr</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>


### PR DESCRIPTION
Hi Stephan,

Could you please update the version dependency for `bigdataviewer-omezarr`? It's a bugfix for path reading/saving. Also I harmonized the n5 and similar package versions with BigStitcher-Spark main but the Fiji bundle of n5 is newer, I think. If you upgrade those, then I'll make another release of `bigdataviewer-omezarr`. Thanks!