### PR TITLE
Add authentication option and some support to path-like s3 uri-s for region specification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.bigdataviewer</groupId>
             <artifactId>bigdataviewer-omezarr</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkAffineFusion.java
@@ -92,6 +92,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 	@Option(names = { "--maxIntensity" }, description = "max intensity for scaling values to the desired range (required for UINT8 and UINT16), e.g. 2048.0")
 	private Double maxIntensity = null;
 
+
 	// TODO: support create custom downsampling pyramids, null is fine for now (used by multiRes later)
 	private int[][] downsamplings;
 
@@ -237,10 +238,11 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 		}
 		catch (Exception e ) {}
 
-		final N5Writer driverVolumeWriter = N5Util.createWriter( n5Path, storageType );
+		System.out.println( "Path: " + n5Path );
+		final N5Writer driverVolumeWriter = N5Util.createWriter( n5Path, storageType, cloudAuthenticate );
 
 		System.out.println( "Format being written: " + storageType );
-
+		System.out.println( "n5Dataset: " + n5Dataset );
 		driverVolumeWriter.createDataset(
 				n5Dataset,
 				dimensions,
@@ -314,6 +316,7 @@ public class SparkAffineFusion extends AbstractSelectableViews implements Callab
 				anisotropyFactor,
 				minBB,
 				n5Path,
+				cloudAuthenticate,
 				n5Dataset,
 				bdvString,
 				storageType,

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkGeometricDescriptorMatching.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkGeometricDescriptorMatching.java
@@ -224,7 +224,7 @@ public class SparkGeometricDescriptorMatching extends AbstractRegistration
 
 			rddResults = rdd.map( serializedPair ->
 			{
-				final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath );
+				final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath , cloudAuthenticate);
 				final Pair<ViewId, ViewId> pair = Spark.derserializeViewIdPairsForRDD( serializedPair );
 
 				//System.out.println( Group.pvid( pair.getA() ) + " <=> " + Group.pvid( pair.getB() ) );
@@ -301,7 +301,7 @@ public class SparkGeometricDescriptorMatching extends AbstractRegistration
 
 			rddResults = rdd.map( serializedGroupPair ->
 			{
-				final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath );
+				final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath, cloudAuthenticate );
 				final Pair<Group<ViewId>, Group<ViewId>> pair = Spark.deserializeGroupedViewIdPairForRDD( serializedGroupPair );
 
 				final ArrayList< ViewId > views = new ArrayList<>();

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
@@ -281,7 +281,7 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 		// return ViewId, interval, locations, intensities
 		final JavaRDD< Tuple4<int[], long[][], double[][], double[] > > rddResult = rddJob.map( serializedInput ->
 		{
-			final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath );
+			final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath, cloudAuthenticate );
 			final ViewId viewId = Spark.deserializeViewId( serializedInput._1() );
 			final ViewDescription vd = data.getSequenceDescription().getViewDescription( viewId );
 

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkNonRigidFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkNonRigidFusion.java
@@ -294,7 +294,7 @@ public class SparkNonRigidFusion extends AbstractSelectableViews implements Call
 
 		rdd.foreach(
 				gridBlock -> {
-					final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath);
+					final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath, cloudAuthenticate);
 
 					// be smarter, test which ViewIds are actually needed for the block we want to fuse
 					final Interval fusedBlock =

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkPairwiseStitching.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkPairwiseStitching.java
@@ -148,7 +148,7 @@ public class SparkPairwiseStitching extends AbstractSelectableViews
 
 		final JavaRDD<Tuple2<int[][][], Spark.SerializablePairwiseStitchingResult>> rddResults = rdd.map( serializedGroupPair ->
 		{
-			final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath );
+			final SpimData2 data = Spark.getSparkJobSpimData2( xmlPath , cloudAuthenticate);
 			final Pair<Group<ViewId>, Group<ViewId>> pair = Spark.deserializeGroupedViewIdPairForRDD( serializedGroupPair );
 			final ViewRegistrations vrs = data.getViewRegistrations();
 

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkResaveN5.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkResaveN5.java
@@ -253,7 +253,7 @@ public class SparkResaveN5 extends AbstractBasic implements Callable<Void>, Seri
 
 		rdds0.foreach(
 				gridBlock -> {
-					final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath);
+					final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath , cloudAuthenticate);
 					final ViewId viewId = new ViewId( (int)gridBlock[ 3 ][ 0 ], (int)gridBlock[ 3 ][ 1 ]);
 
 					final SetupImgLoader< ? > imgLoader = dataLocal.getSequenceDescription().getImgLoader().getSetupImgLoader( viewId.getViewSetupId() );

--- a/src/main/java/net/preibisch/bigstitcher/spark/abstractcmdline/AbstractBasic.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/abstractcmdline/AbstractBasic.java
@@ -18,13 +18,16 @@ public abstract class AbstractBasic implements Callable<Void>, Serializable
 	@Option(names = { "--dryRun" }, description = "perform a 'dry run', i.e. do not save any results (default: false)")
 	protected boolean dryRun = false;
 
+	@Option(names = { "--cloudAuthenticate" }, description = "look for authentication credentials with the cloud backend (default: false)")
+	protected boolean cloudAuthenticate = false;
+
 	@Option(names = "--localSparkBindAddress", description = "specify Spark bind address as localhost")
 	protected boolean localSparkBindAddress = false;
 
 	public SpimData2 loadSpimData2() throws SpimDataException
 	{
 		System.out.println( "xml: " + xmlPath);
-		final SpimData2 dataGlobal = Spark.getSparkJobSpimData2(xmlPath);
+		final SpimData2 dataGlobal = Spark.getSparkJobSpimData2(xmlPath, cloudAuthenticate);
 
 		return dataGlobal;
 	}

--- a/src/main/java/net/preibisch/bigstitcher/spark/cloud/TestN5Loading.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/cloud/TestN5Loading.java
@@ -86,7 +86,7 @@ public class TestN5Loading
 
 	public static void testLoadInterestPoints() throws SpimDataException, IOException
 	{
-		final SpimData2 data = Spark.getSparkJobSpimData2( "s3://janelia-bigstitcher-spark/Stitching/dataset.xml" );
+		final SpimData2 data = Spark.getSparkJobSpimData2( "s3://janelia-bigstitcher-spark/Stitching/dataset.xml" , false );
 
 		System.out.println( "num viewsetups: " + data.getSequenceDescription().getViewSetupsOrdered().size() );
 
@@ -103,7 +103,7 @@ public class TestN5Loading
 
 		System.out.println( "Saving s3://janelia-bigstitcher-spark/Stitching/dataset-save.xml ...");
 
-		Spark.saveSpimData2( data, "s3://janelia-bigstitcher-spark/Stitching/dataset-save.xml" );
+		Spark.saveSpimData2( data, "s3://janelia-bigstitcher-spark/Stitching/dataset-save.xml" , false );
 
 		System.out.println( "Done.");
 	}
@@ -112,7 +112,7 @@ public class TestN5Loading
 	{
 		new ImageJ();
 
-		final SpimData2 data = Spark.getSparkJobSpimData2( xml );
+		final SpimData2 data = Spark.getSparkJobSpimData2( xml , false );
 
 		final BasicImgLoader imgLoader = data.getSequenceDescription().getImgLoader();
 		if (imgLoader instanceof ViewerImgLoader)

--- a/src/main/java/net/preibisch/bigstitcher/spark/fusion/WriteSuperBlock.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/fusion/WriteSuperBlock.java
@@ -47,6 +47,8 @@ public class WriteSuperBlock implements VoidFunction< long[][] >
 
 	private final String n5Path;
 
+	private final boolean authenticate;
+
 	private final String n5Dataset;
 
 	private final String bdvString;
@@ -71,6 +73,7 @@ public class WriteSuperBlock implements VoidFunction< long[][] >
 			final double anisotropyFactor,
 			final long[] minBB,
 			final String n5Path,
+			final boolean authenticate,
 			final String n5Dataset,
 			final String bdvString,
 			final StorageType storageType,
@@ -86,6 +89,7 @@ public class WriteSuperBlock implements VoidFunction< long[][] >
 		this.anisotropyFactor = anisotropyFactor;
 		this.minBB = minBB;
 		this.n5Path = n5Path;
+		this.authenticate = authenticate;
 		this.n5Dataset = n5Dataset;
 		this.bdvString = bdvString;
 		this.storageType = storageType;
@@ -155,7 +159,7 @@ public class WriteSuperBlock implements VoidFunction< long[][] >
 		// --------------------------------------------------------
 
 		// custom serialization
-		final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath);
+		final SpimData2 dataLocal = Spark.getSparkJobSpimData2(xmlPath, authenticate);
 		final List< ViewId > viewIds = Spark.deserializeViewIds( serializedViewIds );
 
 		// If requested, preserve the anisotropy of the data (such that
@@ -190,7 +194,7 @@ public class WriteSuperBlock implements VoidFunction< long[][] >
 		Arrays.setAll( fusedBlockMax, d -> superBlockOffset[ d ] + superBlockSize[ d ] - 1 );
 		final List< ViewId > overlappingViews = findOverlappingViews( dataLocal, viewIds, fusedBlock );
 
-		final N5Writer executorVolumeWriter = N5Util.createWriter( n5Path, storageType );
+		final N5Writer executorVolumeWriter = N5Util.createWriter( n5Path, storageType, authenticate );
 		final ExecutorService prefetchExecutor = Executors.newCachedThreadPool(); //Executors.newFixedThreadPool( N_PREFETCH_THREADS );
 
 		final CellGrid blockGrid = new CellGrid( superBlockSize, blockSize );

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/Import.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/Import.java
@@ -286,7 +286,7 @@ public class Import {
 		}
 		else
 		{
-			new RuntimeException( "BDV-compatible dataset cannot be written for " + storageType + " (yet).");
+			throw new RuntimeException( "BDV-compatible dataset cannot be written for " + storageType + " (yet).");
 		}
 
 		System.out.println( "Saving BDV-compatible " + storageType + " using ViewSetupId=" + viewId.getViewSetupId() + ", TimepointId=" + viewId.getTimePointId()  );

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/N5Util.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/N5Util.java
@@ -18,19 +18,34 @@ public class N5Util
 
 	public static N5Writer createWriter(
 			final String path,
-			final StorageType storageType ) throws IOException // can be null if N5 or ZARR is written 
+			final StorageType storageType ) throws IOException // can be null if N5 or ZARR is written
+	{
+		return createWriter( path, storageType, false );
+	}
+
+	public static N5Writer createWriter(
+			final String path,
+			final StorageType storageType, final boolean authenticate ) throws IOException // can be null if N5 or ZARR is written
 	{
 		if ( StorageType.N5.equals(storageType) )
 		{
-			if ( path.contains( ":/" ) )
-				return new N5Factory().openWriter(StorageFormat.N5, path );
+			if ( path.contains( ":/" ) ) {
+				final N5Factory n5f = new N5Factory();
+				if ( authenticate )
+					n5f.s3UseCredentials();
+				return n5f.openWriter(StorageFormat.N5, path);
+			}
 			else
 				return new N5FSWriter(path);
 		}
 		else if ( StorageType.ZARR.equals(storageType) )
 		{
-			if ( path.contains( ":/" ) )
-				return new N5Factory().openWriter(StorageFormat.ZARR, path );
+			if ( path.contains( ":/" ) ) {
+				final N5Factory n5f = new N5Factory().zarrDimensionSeparator("/");
+				if ( authenticate )
+					n5f.s3UseCredentials();
+				return n5f.openWriter(StorageFormat.ZARR, path);
+			}
 			else
 				return new N5ZarrWriter(path);
 		}

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
@@ -217,7 +217,7 @@ public class Spark {
 		return sparkEnv == null ? null : sparkEnv.executorId();
 	}
 
-	public static void saveSpimData2(final SpimData2 data, final String xmlPath) throws SpimDataException, IOException
+	public static void saveSpimData2(final SpimData2 data, final String xmlPath, final boolean authenticate) throws SpimDataException, IOException
 	{
 		if ( xmlPath.trim().contains( ":/" ) )
 		{
@@ -225,7 +225,7 @@ public class Spark {
 			// saving the XML to s3
 			//
 			final ParsedBucket pb = CloudUtil.parseCloudLink( xmlPath );
-			final KeyValueAccess kva = CloudUtil.getKeyValueAccessForBucket( pb );
+			final KeyValueAccess kva = CloudUtil.getKeyValueAccessForBucket( pb, authenticate );
 
 			// fist make a copy of the XML and save it to not loose it
 			if ( kva.exists( pb.rootDir + "/" + pb.file ) )
@@ -276,7 +276,7 @@ public class Spark {
 	/**
 	 * @return a new data instance optimized for use within single-threaded Spark tasks.
 	 */
-	public static SpimData2 getSparkJobSpimData2(final String xmlPath)
+	public static SpimData2 getSparkJobSpimData2(final String xmlPath, final boolean authenticate)
 			throws SpimDataException {
 
 		final SpimData2 data;
@@ -284,7 +284,7 @@ public class Spark {
 		if ( xmlPath.contains( ":/" ) )
 		{
 			final ParsedBucket pb = CloudUtil.parseCloudLink( xmlPath );
-			final KeyValueAccess kva = CloudUtil.getKeyValueAccessForBucket( pb );
+			final KeyValueAccess kva = CloudUtil.getKeyValueAccessForBucket( pb, authenticate);
 
 			final SAXBuilder sax = new SAXBuilder();
 			Document doc;


### PR DESCRIPTION
Hi Stephan,

please find a draft solution for having both the authentication and the region passing through N5Factory. 

* I added a cmd line option to explicitly request the authentication from the backend (at the moment s3 only). This is necessary for the output bucket writing, because the credentials are based on the assumed role in the EMR-serverless session.

* Unless the path-like s3 uri (`https://s3-us-west-2.amazonaws.com/bucket/...`) is used, N5Factory falls back to `us-east-1` which does not work for us. Updated `ParsedBucket` to tolerate path-like uri-s. Maybe we don't really want to use path-like URI-s in the long term but using N5Factory.s3Region to set region obtained from the `DefaultAwsRegionProviderChain`. [See related issue here.](https://github.com/saalfeldlab/n5-universe/issues/20) 

* Also note that while this branch works with n5-aws-s3 4.1.1, it fails with key error in 4.1.3 : 
```
mpicbg.spim.data.SpimDataIOException: com.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: B6CKA6GRDWMBAXWE; S3 Extended Request ID: KUW8//nsXQhv7NIQlZ1pCe801MBlpYnnrwsCtV01VPgy6tCjR+PryJUtmzxJ/3xAA114oWUI4m4=; Proxy: null), S3 Extended Request ID: KUW8//nsXQhv7NIQlZ1pCe801MBlpYnnrwsCtV01VPgy6tCjR+PryJUtmzxJ/3xAA114oWUI4m4=
	at net.preibisch.bigstitcher.spark.util.Spark.getSparkJobSpimData2(Spark.java:298)
	at net.preibisch.bigstitcher.spark.abstractcmdline.AbstractBasic.loadSpimData2(AbstractBasic.java:30)
	at net.preibisch.bigstitcher.spark.SparkAffineFusion.call(SparkAffineFusion.java:130)
```