### PR TITLE
use version 1.3.5 of n5-zarr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-zarr</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>


### PR DESCRIPTION
bumps the version of `n5-zarr` from 1.2.1 to 1.3.5 (the latest version)

`n5-zarr` versions prior to 1.3.2 could create invalid zarr arrays due to storing the `fill_value` attribute as a string. John fixed this in [this PR](https://github.com/saalfeldlab/n5-zarr/pull/40). Using a recent version of `n5-zarr` will include his fix and avoid the problem of creating invalid zarr arrays.