### PR TITLE
Serialize interest points into N5 as it can be too big for Spark

### DIFF
--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
@@ -828,25 +828,7 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 				if ( !maxSpotsPerOverlap && maxSpots > 0 && maxSpots < myIpsNewId.size() )
 				{
 					filterPoints( myIpsNewId, myIntensities, maxSpots );
-					/*
-					// filter for the brightnest N spots
-					final ArrayList< Pair< Double, InterestPoint > > combinedList = new ArrayList<>();
 
-					for ( int i = 0; i < myIps.size(); ++i )
-						combinedList.add( new ValuePair<Double, InterestPoint>(myIntensities.get( i ), myIpsNewId.get( i )));
-
-					// sort from large to small
-					Collections.sort(combinedList, (a,b) -> b.getA().compareTo( a.getA() ) );
-
-					myIpsNewId.clear();
-					myIntensities.clear();
-
-					for ( int i = 0; i < maxSpots; ++i )
-					{
-						myIntensities.add( combinedList.get( i ).getA() );
-						myIpsNewId.add( new InterestPoint( i, combinedList.get( i ).getB().getL() ) ); // new id's again ...
-					}
-					*/
 					System.out.println( Group.pvid( viewId ) + " (after applying maxSpots): " + myIpsNewId.size() );
 				}
 
@@ -872,14 +854,14 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 					interestPoints.put( viewId, new ArrayList<>() );
 
 			// save XML
+			System.out.println( "Saving XML and interest points ..." );
+
 			final String params = "DOG (Spark) s=" + sigma + " t=" + threshold + " overlappingOnly=" + overlappingOnly + " min=" + findMin + " max=" + findMax +
 					" downsampleXY=" + downsampleXY + " downsampleZ=" + downsampleZ + " minIntensity=" + minIntensity + " maxIntensity=" + maxIntensity;
 
 			InterestPointTools.addInterestPoints( dataGlobal, label, interestPoints, params );
 
-			System.out.println( "Saving XML and interest points ..." );
-
-			new XmlIoSpimData2().save( dataGlobal, xmlURI ); // TODO: this must be over-writing interestpoint folder
+			new XmlIoSpimData2().save( dataGlobal, xmlURI );
 
 			// store image intensities for interest points
 			if( storeIntensities )
@@ -892,7 +874,6 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 
 					final String datasetIntensities = i.ipDataset() + "/intensities";
 
-					System.out.println( "points: " + interestPoints.get( viewId ).size() );
 					if ( interestPoints.get( viewId ).size() == 0 )
 					{
 						n5Writer.createDataset(
@@ -904,7 +885,6 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 					}
 					else
 					{
-						System.out.println( "intesnity:" + intensitiesIPs.get( viewId ).size() );
 						List<Double> intensitiesList = intensitiesIPs.get( viewId );
 
 						// 1 x N array (which is a 2D array)
@@ -920,8 +900,6 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 
 						final RandomAccessibleInterval< FloatType > intensityData =
 								Views.interval( intensities, new long[] { 0, 0 }, new long[] { 0, intensitiesList.size() - 1 } );
-
-						System.out.println( "intesnity interval:" + Util.printInterval( intensityData ) );
 
 						N5Utils.save( intensityData, n5Writer, datasetIntensities, new int[] { 1, InterestPointsN5.defaultBlockSize }, new ZstandardCompression() );
 					}

--- a/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/SparkInterestPointDetection.java
@@ -902,7 +902,7 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 								new long[] {0},
 								new int[] {1},
 								DataType.FLOAT32,
-								new GzipCompression());
+								new ZstandardCompression());
 					}
 					else
 					{
@@ -919,29 +919,31 @@ public class SparkInterestPointDetection extends AbstractSelectableViews impleme
 											value.set( intensitiesList.get( index ).floatValue() );
 										},
 										FloatType::new );
-	
+
 						final RandomAccessibleInterval< FloatType > intensityData =
 								Views.interval( intensities, new long[] { 0, 0 }, new long[] { 0, intensitiesList.size() - 1 } );
-	
-						N5Utils.save( intensityData, n5Writer, datasetIntensities, new int[] { 1, InterestPointsN5.defaultBlockSize }, new GzipCompression() );
+
+						System.out.println( "intesnity interval:" + Util.printInterval( intensityData ) );
+
+						N5Utils.save( intensityData, n5Writer, datasetIntensities, new int[] { 1, InterestPointsN5.defaultBlockSize }, new ZstandardCompression() );
 					}
 
-					IOFunctions.println( "Saved: " + URITools.appendName( i.getBaseDir(), InterestPointsN5.baseN5 ) + ":/" + datasetIntensities );
+					System.out.println( "Saved: " + tempURI + "/" + datasetIntensities );
 				}
 			}
-
-			n5Writer.close();
 
 			// save XML
 			final String params = "DOG (Spark) s=" + sigma + " t=" + threshold + " overlappingOnly=" + overlappingOnly + " min=" + findMin + " max=" + findMax +
 					" downsampleXY=" + downsampleXY + " downsampleZ=" + downsampleZ + " minIntensity=" + minIntensity + " maxIntensity=" + maxIntensity;
-	
+
 			InterestPointTools.addInterestPoints( dataGlobal, label, interestPoints, params );
 
 			System.out.println( "Saving XML (metadata only) ..." );
-	
-			new XmlIoSpimData2().save( dataGlobal, xmlURI );
+
+			new XmlIoSpimData2().save( dataGlobal, xmlURI ); // TODO: this must be over-writing interestpoint folder
 		}
+
+		n5Writer.close();
 
 		System.out.println( "Done ..." );
 

--- a/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/util/Spark.java
@@ -36,12 +36,17 @@ import mpicbg.spim.data.SpimDataException;
 import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.sequence.SequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
+import net.imglib2.view.Views;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.XmlIoSpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.interestpoints.InterestPoint;
@@ -160,12 +165,20 @@ public class Spark {
 		return serializedViewIds;
 	}
 
-	public static ArrayList< InterestPoint > deserializeInterestPoints( final double[][] points )
+	public static ArrayList< InterestPoint > deserializeInterestPoints( final RandomAccessibleInterval<DoubleType> points )
 	{
 		final ArrayList< InterestPoint > list = new ArrayList<>();
-		
-		for ( int i = 0; i < points.length; ++i )
-			list.add( new InterestPoint(i, points[ i ] ));
+		final Cursor< DoubleType > cursor = Views.flatIterable( points ).localizingCursor();
+
+		for ( int i = 0; i < points.dimension( 1 ); ++i )
+		{
+			final double[] l = new double[ (int)points.dimension( 0 ) ];
+
+			for ( int d = 0; d < points.dimension( 0 ); ++d )
+				l[ d ] = cursor.next().get();
+
+			list.add( new InterestPoint(i, l ));
+		}
 
 		return list;
 	}


### PR DESCRIPTION
When detecting tons of interest points and returning them through Spark can lead to errors (e.g. `Total size of serialized results of 4317 tasks (1024.6 MiB) is bigger than spark.driver.maxResultSize (1024.0 MiB)`).

Now points are saved into a temporary N5 that is later removed.

@tpietzsch @krokicki @mkitti 